### PR TITLE
add instruction to access directly to the team and not to the channels

### DIFF
--- a/slides/00 - intro/00-intro.tex
+++ b/slides/00 - intro/00-intro.tex
@@ -181,7 +181,7 @@ si incoraggia l'uso del \textbf{Forum del Corso}
     Per accedere al team \textbf{OOP-Lab} sono disponibili due modalità:
     \begin{block}{Via link}
         \begin{itemize}
-            \item \textbf{URL}: \url{https://bit.ly/34i4Ksa}
+            \item \textbf{URL}: \url{http://bit.ly/teamoop2020}
             \item Richiede la conferma da parte di un docente, quindi l'accesso non è immediato
         \end{itemize}
     \end{block}


### PR DESCRIPTION
Messe instruzioni per accedere direttamente al team OOP-Lab così possiamo eliminare i canali al termine delle lezioni